### PR TITLE
(버그 수정 및 리팩토링) 액티비티 새로 생성하지 않게 만듬.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,10 +28,10 @@
 
         <activity
             android:name=".views.MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>

--- a/app/src/main/java/com/example/audiorecorder/views/MainFragment.kt
+++ b/app/src/main/java/com/example/audiorecorder/views/MainFragment.kt
@@ -122,6 +122,11 @@ class MainFragment : Fragment() {
     private fun startRecord() {
         Log.d(TAG,"MainFragment - startRecord() called")
         originalName = "${System.currentTimeMillis()}.mp3"
+        startRecordService()
+    }
+
+    // 녹음 서비스 실행
+    private fun startRecordService() {
         recordService = Intent(requireActivity(), RecordService::class.java)
         recordService.putExtra("originalName", originalName)
 


### PR DESCRIPTION
문제 :
타이머를 시작했을 때, 알림이 나온다.
알림을 클릭했을 때, 실행 중인 액티비티가 나와야 하는데 액티비티가 새로 생성 된다.

해결 :
launchMode를 singleTask로 변경해주었다.

참고자료 : https://developer.android.com/guide/topics/manifest/activity-element?hl=ko#lmode